### PR TITLE
Allow prompt-only image generation

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -15,7 +15,7 @@
                             🍌 Nano<br />
                             <span class="text-yellow-100 text-5xl">Banana</span>
                         </h1>
-                        <p class="text-white text-base font-medium">Upload your images and I'll create art!</p>
+                        <p class="text-white text-base font-medium">Upload inspiration images or let me create art from scratch!</p>
                     </div>
                 </div>
             </div>
@@ -49,7 +49,7 @@
             <div class="grid lg:grid-cols-2 gap-4 lg:gap-6 mb-6 lg:items-stretch min-h-[400px]">
                 <!-- Left column: image upload -->
                 <div class="flex flex-col h-full">
-                    <div class="bg-pink-400 text-white font-bold px-4 py-2 rounded-t-lg border-4 border-black border-b-0 flex items-center gap-2">🍌 1. Upload images</div>
+                    <div class="bg-pink-400 text-white font-bold px-4 py-2 rounded-t-lg border-4 border-black border-b-0 flex items-center gap-2">🍌 1. Upload images (optional)</div>
                     <div class="flex-1">
                         <ImageUpload v-model="selectedImages" />
                     </div>
@@ -141,7 +141,22 @@ watch([selectedStyle, customPrompt], () => {
     }
 })
 
-const canGenerate = computed(() => apiKey.value.trim() && selectedImages.value.length > 0 && (selectedStyle.value || customPrompt.value.trim()) && !isLoading.value)
+const resolvePrompt = () => {
+    if (selectedStyle.value) {
+        const templatePrompt = styleTemplates.find(t => t.id === selectedStyle.value)?.prompt
+        return templatePrompt || customPrompt.value
+    }
+
+    return customPrompt.value
+}
+
+const canGenerate = computed(() => {
+    if (!apiKey.value.trim() || isLoading.value) {
+        return false
+    }
+
+    return resolvePrompt().trim().length > 0
+})
 
 const handleGenerate = async () => {
     if (!canGenerate.value) return
@@ -153,7 +168,7 @@ const handleGenerate = async () => {
 
     try {
         // Use the selected style template or the custom prompt
-        const prompt = selectedStyle.value ? styleTemplates.find(t => t.id === selectedStyle.value)?.prompt || customPrompt.value : customPrompt.value
+        const prompt = resolvePrompt()
 
         const request: GenerateRequest = {
             prompt,

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -4,15 +4,17 @@ const OPENROUTER_API_URL = 'https://openrouter.ai/api/v1/chat/completions'
 
 export async function generateImage(request: GenerateRequest): Promise<GenerateResponse> {
     // Build the OpenRouter API request payload
+    const imageContent = (request.images ?? []).map(img => ({
+        type: 'image_url' as const,
+        image_url: { url: img }
+    }))
+
     const messages = [
         {
             role: 'user',
             content: [
                 { type: 'text', text: request.prompt },
-                ...request.images.map(img => ({
-                    type: 'image_url',
-                    image_url: { url: img }
-                }))
+                ...imageContent
             ]
         }
     ]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,6 @@
 export interface GenerateRequest {
     prompt: string
-    images: string[]
+    images?: string[]
     apikey: string
 }
 


### PR DESCRIPTION
## Summary
- make the OpenRouter image payload optional so requests can be issued without uploads
- relax the UI validation so generations can be run from a prompt alone and clarify the copy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0f4ab55e883279e9d2ac82e93c1ab